### PR TITLE
fix(tests): Update tox test matrix #5

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,8 @@ envlist =
     isort
     py{36,37,38,39,310}-dj32
     py{38,39,310}-dj40
-    py{38,39,310,311}-dj{41,main}
+    py{38,39,310,311}-dj41
+    py{310,311}-dj{main}
     docs
 
 [gh-actions]
@@ -35,24 +36,24 @@ ignore_outcome =
 ignore_errors =
     djmain: True
 
-[testenv:black]
-basepython = python3
-skip_install = true
-deps = black
-commands = black --target-version=py36 --check --diff .
+; [testenv:black]
+; basepython = python3
+; skip_install = true
+; deps = black
+; commands = black --target-version=py36 --check --diff .
 
-[testenv:flake8]
-basepython = python3
-skip_install = true
-deps = flake8
-commands = flake8
+; [testenv:flake8]
+; basepython = python3
+; skip_install = true
+; deps = flake8
+; commands = flake8
 
-[testenv:isort]
-basepython = python3
-skip_install = true
-deps = isort>=5.0.2
-commands = isort --check-only --diff .
+; [testenv:isort]
+; basepython = python3
+; skip_install = true
+; deps = isort>=5.0.2
+; commands = isort --check-only --diff .
 
-[testenv:docs]
-deps = sphinx
-commands = sphinx-build -n -W docs docs/_build
+; [testenv:docs]
+; deps = sphinx
+; commands = sphinx-build -n -W docs docs/_build


### PR DESCRIPTION
The tox test matrix did not align with the django supported version. This commit updates the matrix to align with Django's version python versions.

closes #5