### PR TITLE
chore(Release): Update workflow #39

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,13 +45,8 @@ Tracker = "https://github.com/imAsparky/django-tag-fields/issues"
 
 [tool.semantic_release]
 branch = "main"
-build_command = "pyproject-build"
-check_build_status = true
+build_command = 'python -m pip install flit && flit build'
 commit_subject = ":memo: build(version): Bump to version - {version}."
-major_on_zero = false
-remove_dist = false
-upload_to_release = false
-upload_to_pypi = true
 version_variable = "docs/conf.py:__version__,tag_fields/__init__.py:__version__"
 
 


### PR DESCRIPTION
The release workflow wasn't generating a new version number, so the build and release where failing.
Simplified the flags in pyproject to check that there werent any weird interactions.

closes #39