### PR TITLE
chore(release): Add changelog_file attr #39

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,13 +45,9 @@ Tracker = "https://github.com/imAsparky/django-tag-fields/issues"
 
 [tool.semantic_release]
 branch = "main"
-build_command = "pyproject-build"
-check_build_status = true
+build_command = 'python -m pip install flit && flit build'
+changelog_file = "CHANGELOG.rst"
 commit_subject = ":memo: build(version): Bump to version - {version}."
-major_on_zero = false
-remove_dist = false
-upload_to_release = false
-upload_to_pypi = true
 version_variable = "docs/conf.py:__version__,tag_fields/__init__.py:__version__"
 
 


### PR DESCRIPTION
By default python semantic release looks for CHANGELOG.md. This project uses CHANGELOG.rst, so it needs to know this.

closes #39