### PR TITLE
chore(release): add changelog_file attr #43

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,17 +19,6 @@ jobs:
           # python-semantic-release can decide if a new release is needed.
           fetch-depth: 0
 
-      # - name: Set up Python
-      #   uses: actions/setup-python@v4
-      #   with:
-      #     python-version: "3.11"
-
-      # - name: Build package
-      #   run: |
-      #     python3 setup.py --version
-      #     python3 setup.py sdist --format=gztar bdist_wheel
-      #     twine check dist/*
-
       - uses: relekang/python-semantic-release@master
         with:
           github_token: ${{ secrets.PYPI_RELEASE_TOKEN }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ Tracker = "https://github.com/imAsparky/django-tag-fields/issues"
 [tool.semantic_release]
 branch = "main"
 build_command = 'python -m pip install flit && flit build'
+changelog_file = "CHANGELOG.rst"
 commit_subject = ":memo: build(version): Bump to version - {version}."
 version_variable = "docs/conf.py:__version__,tag_fields/__init__.py:__version__"
 


### PR DESCRIPTION
By default python semantic release looks for CHANGELOG.md. This project uses CHANGELOG.rst, so it needs to know this.

closes #43