### PR TITLE
:memo: build(version): Bump to version - 4.0.0.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,7 @@ Changelog
 
 <!--next-version-placeholder-->
 
+
 4.0.0 (2023-03-30)
 ~~~~~~~~~~~~~~~~~~
 * Initial release of django-tag-fields.


### PR DESCRIPTION
This commit is for python semantic version to work.  Python Semantic version checks the commits already in the repo for a commit that includes the current version.  It checks the existing version  to make sure there are no errors when calculating the next version from the new commit messages.

close #45